### PR TITLE
Upgrade notepadequalequal and remove useless syspath

### DIFF
--- a/src/notepadequalequal/Notepad==.py
+++ b/src/notepadequalequal/Notepad==.py
@@ -1,4 +1,7 @@
-import main
+try:
+    from . import main
+except Exception:
+    import main
 
 if __name__ == "__main__":
     main.main()

--- a/src/notepadequalequal/__init__.py
+++ b/src/notepadequalequal/__init__.py
@@ -1,0 +1,3 @@
+# Package initializer for Notepad== Linux src
+# Allows relative imports within this package
+__all__ = []

--- a/src/notepadequalequal/fileio.py
+++ b/src/notepadequalequal/fileio.py
@@ -3,10 +3,15 @@ import sys
 import traceback
 from tkinter import messagebox, filedialog
 import errno
-import common
 import platform
-import platformSpecific as ps
-from exceptions import UnsupportedEncodingError
+try:
+    from . import common
+    from . import platformSpecific as ps
+    from .exceptions import UnsupportedEncodingError
+except Exception:
+    import common
+    import platformSpecific as ps
+    from exceptions import UnsupportedEncodingError
 
 text_area = None
 

--- a/src/notepadequalequal/main.py
+++ b/src/notepadequalequal/main.py
@@ -19,12 +19,20 @@ import re
 import pathlib
 import pyperclip
 import builtins
-import common
-from common import *
-from platformSpecific import *
-import fileio
-from fileio import *
-from correction import *
+try:
+    from . import common
+    from .common import *
+    from .platformSpecific import *
+    from . import fileio
+    from .fileio import *
+    from .correction import *
+except Exception:
+    import common
+    from common import *
+    from platformSpecific import *
+    import fileio
+    from fileio import *
+    from correction import *
 
 # Redirect output to log file
 if __name__ == '__main__':
@@ -350,10 +358,13 @@ def findNext(text):
         end = str(start) + " + " + str(len(text)) + "c"
         text_area.tag_add("highlight", start, end)
     except Exception as e:
-        start = "1.0"
-        start = text_area.search(text, start, stopindex="end")
-        end = str(start) + " + " + str(len(text)) + "c"
-        text_area.tag_add("highlight", start, end)
+        if text in text_area.get('1.0', 'end-1c'):
+            start = "1.0"
+            start = text_area.search(text, start, stopindex="end")
+            end = str(start) + " + " + str(len(text)) + "c"
+            text_area.tag_add("highlight", start, end)
+        else:
+            messagebox.showerror("Text Not Found", "Query not found in text.")
     
     text_area.tag_config("highlight", background="yellow")
     text_area.mark_set("insert", end)

--- a/src/notepadequalequal/platformSpecific.py
+++ b/src/notepadequalequal/platformSpecific.py
@@ -4,9 +4,14 @@ import subprocess
 import threading
 import platform
 from pathlib import Path
-from common import *
-from exceptions import *
-from fileio import *
+try:
+    from .common import *
+    from .exceptions import *
+    from .fileio import *
+except Exception:
+    from common import *
+    from exceptions import *
+    from fileio import *
 
 root = None
 

--- a/src/zencodings.py
+++ b/src/zencodings.py
@@ -3,8 +3,6 @@
 import os
 import sys
 
-sys.path.append(os.path.join(os.path.dirname(__file__), 'notepadequalequal'))
-
 from notepadequalequal.common import encodings
 from notepadequalequal.fileio import retrieve_file
 


### PR DESCRIPTION
This PR just upgrades the `notepadequalequal` module and removes the need for a `sys.path` append. Makes it break less, in other words. Tested and working.