### PR TITLE
Fix save all documents

### DIFF
--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -868,6 +868,8 @@ class Window(MSFluentWindow):
             QMessageBox.critical(self, "Save Error", f"An error occurred while saving the document: {e}")
     
     def save_all_documents(self):
+        savedIndex = self.tabBar.currentIndex()
+
         if self.mode == "markdown":
             self.save_document(dlgName="Markdown Document")
             self.setModeToWrite()
@@ -876,6 +878,8 @@ class Window(MSFluentWindow):
             self.tabBar.setCurrentIndex(i)
             self.onTabChanged(i)
             self.save_document(dlgName=self.tabBar.tabText(i))
+
+        self.tabBar.setCurrentIndex(savedIndex)
 
     def tts(self):
         cursor = self.current_editor.textCursor()

--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -868,6 +868,10 @@ class Window(MSFluentWindow):
             QMessageBox.critical(self, "Save Error", f"An error occurred while saving the document: {e}")
     
     def save_all_documents(self):
+        if self.mode == "markdown":
+            self.save_document(dlgName="Markdown Document")
+            self.setModeToWrite()
+        
         for i in range(self.tabBar.count()):
             self.tabBar.setCurrentIndex(i)
             self.onTabChanged(i)

--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -617,7 +617,7 @@ class Window(MSFluentWindow):
         for _, text_widget in self.text_widgets:
             a += text_widget.toPlainText()
 
-        if a != "":
+        if a.strip() != "":
 
             w = MessageBox(
                 'Confirm Exit',

--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -614,7 +614,7 @@ class Window(MSFluentWindow):
             self.getEditorType()
         
         a = ""
-        for _, text_widget in self.text_widgets:
+        for _, text_widget in self.text_widgets.items():
             a += text_widget.toPlainText()
 
         if a.strip() != "":

--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -613,10 +613,9 @@ class Window(MSFluentWindow):
         if not self.current_editor:
             self.getEditorType()
         
-        if self.current_editor:
-            a = self.current_editor.toPlainText()
-        else:
-            a = ""
+        a = ""
+        for _, text_widget in self.text_widgets:
+            a += text_widget.toPlainText()
 
         if a != "":
 

--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -715,6 +715,9 @@ class Window(MSFluentWindow):
             editor = self.current_editor
             if not editor:
                 raise NoEditorSpecified("No editor specified to save from.")
+            if not editor.toPlainText().strip():
+                print("WARNING: No text in editor to save")
+                return
 
             text_to_save = editor.toPlainText()
             name = ""

--- a/src/ZenNotes.py
+++ b/src/ZenNotes.py
@@ -869,6 +869,7 @@ class Window(MSFluentWindow):
     
     def save_all_documents(self):
         savedIndex = self.tabBar.currentIndex()
+        navigationInterfaceItem = self.navigationInterface.currentItem()
 
         if self.mode == "markdown":
             self.save_document(dlgName="Markdown Document")
@@ -880,6 +881,7 @@ class Window(MSFluentWindow):
             self.save_document(dlgName=self.tabBar.tabText(i))
 
         self.tabBar.setCurrentIndex(savedIndex)
+        self.navigationInterface.setCurrentItem(navigationInterfaceItem)
 
     def tts(self):
         cursor = self.current_editor.textCursor()


### PR DESCRIPTION
This PR makes the save all documents account for markdown documents and restores the editor widget back to whatever it was before saving all documents